### PR TITLE
fix: MediaWrapper broken in net standard

### DIFF
--- a/src/MediaInfo.DotNetWrapper/MediaInfoWrapper.cs
+++ b/src/MediaInfo.DotNetWrapper/MediaInfoWrapper.cs
@@ -80,12 +80,13 @@ namespace MediaInfo.DotNetWrapper
             Chapters = new List<ChapterStream>();
             MenuStreams = new List<MenuStream>();
 
+#if !NETSTANDARD2_0
             if (!MediaInfoExist(pathToDll))
             {
                 MediaInfoNotloaded = true;
                 return;
             }
-
+#endif
             if (string.IsNullOrEmpty(filePath))
             {
                 MediaInfoNotloaded = true;
@@ -290,6 +291,7 @@ namespace MediaInfo.DotNetWrapper
 
         #endregion
 
+#if !NETSTANDARD2_0
         /// <summary>
         /// Checks if mediaInfo.dll file exist.
         /// </summary>
@@ -299,6 +301,7 @@ namespace MediaInfo.DotNetWrapper
         {
             return File.Exists(Path.Combine(pathToDll, "MediaInfo.dll"));
         }
+#endif
 
         #region private methods
 


### PR DESCRIPTION
I wasn't aware of the MediaInfoWrapper class. I worked with the classes I saw in the test console apps. Quick fix to support MediaInfoWrapper class.

Thanks for the quick NuGet push and my apologies for missing the wrapper class.