### PR TITLE
Target Net Standard 1.3

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to find out which attributes exist for C# debugging
+    // Use hover for the description of the existing attributes
+    // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+    "version": "0.2.0",
+    "configurations": [
+        
+         {
+             "name": "MediaInfo.DotNetWrapper.ConsoleTest.NetCore20",
+             "type": "coreclr",
+             "request": "launch",
+             "preLaunchTask": "build",
+             // If you have changed target frameworks, make sure to update the program path.
+             "program": "${workspaceFolder}/test/MediaInfo.DotNetWrapper.ConsoleTest.NetCore20/bin/Debug/netcoreapp2.0/MediaInfo.DotNetWrapper.ConsoleTest.NetCore20.dll",
+             "args": [],
+             "cwd": "${workspaceFolder}/test/MediaInfo.DotNetWrapper.ConsoleTest.NetCore20",
+             "stopAtEntry": false,
+             "internalConsoleOptions": "openOnSessionStart",
+             "env": {
+                 "ASPNETCORE_ENVIRONMENT": "Development"
+             }
+         }
+     ]
+ }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/test/MediaInfo.DotNetWrapper.ConsoleTest.NetCore20/MediaInfo.DotNetWrapper.ConsoleTest.NetCore20.csproj",
+                "--no-restore"
+            ],
+            "problemMatcher": "$msCompile"
+        }        
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Based on [MP-MediaInfo](https://github.com/yartat/MP-MediaInfo).
 
 For example see : test\MediaInfo.DotNetWrapper.ConsoleTest
 
-# Targeting .Net Standard 2.0 / .Net Core 2.0
+# Targeting .Net Standard 1.3
 
 MediaInfo.Native is not included when targeting .Net Standard / Core. Manually include MediaInfo native libaries for your operating system / platform.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
 build_script:
 - dotnet restore .\src\MediaInfo.DotNetWrapper\MediaInfo.DotNetWrapper.csproj
 - dotnet build .\src\MediaInfo.DotNetWrapper\MediaInfo.DotNetWrapper.csproj --framework net40 -c %CONFIGURATION%
-- dotnet build .\src\MediaInfo.DotNetWrapper\MediaInfo.DotNetWrapper.csproj --framework netstandard2.0 -c %CONFIGURATION%
+- dotnet build .\src\MediaInfo.DotNetWrapper\MediaInfo.DotNetWrapper.csproj --framework netstandard1.3 -c %CONFIGURATION%
 
 artifacts:
 - path: artifacts\**\*.*

--- a/src/MediaInfo.DotNetWrapper/FileNameExtensions.cs
+++ b/src/MediaInfo.DotNetWrapper/FileNameExtensions.cs
@@ -251,7 +251,7 @@ namespace MediaInfo.DotNetWrapper
             return path.StartsWith(@"http://play.last.fm", StringComparison.OrdinalIgnoreCase);
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_3
         /// <summary>
         /// Determines whether specified path is network path.
         /// </summary>

--- a/src/MediaInfo.DotNetWrapper/MediaInfo.DotNetWrapper.csproj
+++ b/src/MediaInfo.DotNetWrapper/MediaInfo.DotNetWrapper.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MediaInfo.DotNetWrapper</AssemblyTitle>
     <VersionPrefix>1.0.5.0</VersionPrefix>
     <Authors>Yaroslav V Tatarenko;Stef Heyenrath</Authors>
-    <TargetFrameworks>net35;net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;netstandard1.3</TargetFrameworks>
     <AssemblyName>MediaInfo.DotNetWrapper</AssemblyName>
     <PackageId>MediaInfo.DotNetWrapper</PackageId>
     <PackageTags>MediaInfo;MediaInfo.dll;MediaInfo.Native;DotNetWrapper;wrapper;dotnet;c#;.net</PackageTags>
@@ -25,7 +25,12 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.IO" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
     <PackageReference Include="MediaInfo.Native" Version="17.12.0" />
   </ItemGroup>
 

--- a/src/MediaInfo.DotNetWrapper/MediaInfo.DotNetWrapper.csproj
+++ b/src/MediaInfo.DotNetWrapper/MediaInfo.DotNetWrapper.csproj
@@ -28,6 +28,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
     <PackageReference Include="System.IO" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">

--- a/src/MediaInfo.DotNetWrapper/MediaInfo.cs
+++ b/src/MediaInfo.DotNetWrapper/MediaInfo.cs
@@ -22,10 +22,10 @@ namespace MediaInfo.DotNetWrapper
                 _handle = IntPtr.Zero;
             }
 
-#if !NETSTANDARD1_3
-            _mustUseAnsi = Environment.OSVersion.ToString().IndexOf("Windows", StringComparison.OrdinalIgnoreCase) == -1;
+#if NETSTANDARD1_3
+            _mustUseAnsi = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 #else
-            _mustUseAnsi = true;
+            _mustUseAnsi = Environment.OSVersion.ToString().IndexOf("Windows", StringComparison.OrdinalIgnoreCase) == -1;
 #endif
         }
 

--- a/src/MediaInfo.DotNetWrapper/MediaInfo.cs
+++ b/src/MediaInfo.DotNetWrapper/MediaInfo.cs
@@ -22,7 +22,11 @@ namespace MediaInfo.DotNetWrapper
                 _handle = IntPtr.Zero;
             }
 
+#if !NETSTANDARD1_3
             _mustUseAnsi = Environment.OSVersion.ToString().IndexOf("Windows", StringComparison.OrdinalIgnoreCase) == -1;
+#else
+            _mustUseAnsi = true;
+#endif
         }
 
         ~MediaInfo()

--- a/src/MediaInfo.DotNetWrapper/MediaInfoWrapper.cs
+++ b/src/MediaInfo.DotNetWrapper/MediaInfoWrapper.cs
@@ -57,7 +57,7 @@ namespace MediaInfo.DotNetWrapper
 
         #region ctor's
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_3
         /// <summary>
         /// Initializes a new instance of the <see cref="MediaInfoWrapper"/> class.
         /// </summary>
@@ -72,11 +72,11 @@ namespace MediaInfo.DotNetWrapper
         /// Initializes a new instance of the <see cref="MediaInfoWrapper"/> class.
         /// </summary>
         /// <param name="filePath">The file path.</param>
-#if !NETSTANDARD2_0        
+#if !NETSTANDARD1_3        
         /// <param name="pathToDll">The path to DLL.</param>
 #endif        
         protected MediaInfoWrapper(string filePath
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_3
         , string pathToDll)
 #else
         )
@@ -89,7 +89,7 @@ namespace MediaInfo.DotNetWrapper
             Chapters = new List<ChapterStream>();
             MenuStreams = new List<MenuStream>();
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_3
             if (!MediaInfoExist(pathToDll))
             {
                 MediaInfoNotloaded = true;
@@ -300,7 +300,7 @@ namespace MediaInfo.DotNetWrapper
 
         #endregion
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_3
         /// <summary>
         /// Checks if mediaInfo.dll file exist.
         /// </summary>

--- a/src/MediaInfo.DotNetWrapper/MediaInfoWrapper.cs
+++ b/src/MediaInfo.DotNetWrapper/MediaInfoWrapper.cs
@@ -57,6 +57,7 @@ namespace MediaInfo.DotNetWrapper
 
         #region ctor's
 
+#if !NETSTANDARD2_0
         /// <summary>
         /// Initializes a new instance of the <see cref="MediaInfoWrapper"/> class.
         /// </summary>
@@ -65,13 +66,21 @@ namespace MediaInfo.DotNetWrapper
           : this(filePath, Utils.Is64BitProcess ? @".\x64" : @".\x86")
         {
         }
+#endif
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MediaInfoWrapper"/> class.
         /// </summary>
         /// <param name="filePath">The file path.</param>
+#if !NETSTANDARD2_0        
         /// <param name="pathToDll">The path to DLL.</param>
-        protected MediaInfoWrapper(string filePath, string pathToDll)
+#endif        
+        protected MediaInfoWrapper(string filePath
+#if !NETSTANDARD2_0
+        , string pathToDll)
+#else
+        )
+#endif
         {
             MediaInfoNotloaded = false;
             VideoStreams = new List<VideoStream>();
@@ -115,7 +124,7 @@ namespace MediaInfo.DotNetWrapper
                 {
                     if (filePath.EndsWith(".ifo", StringComparison.OrdinalIgnoreCase))
                     {
-                        filePath = ProcessDvd(filePath, pathToDll, providerNumber);
+                        filePath = ProcessDvd(filePath, providerNumber);
                     }
                     else if (filePath.EndsWith(".bdmv", StringComparison.OrdinalIgnoreCase))
                     {
@@ -131,7 +140,7 @@ namespace MediaInfo.DotNetWrapper
                     HasExternalSubtitles = !string.IsNullOrEmpty(filePath) && CheckHasExternalSubtitles(filePath);
                 }
 
-                ExtractInfo(filePath, pathToDll, providerNumber);
+                ExtractInfo(filePath, providerNumber);
             }
             catch
             {
@@ -151,7 +160,7 @@ namespace MediaInfo.DotNetWrapper
             return result;
         }
 
-        private string ProcessDvd(string filePath, string pathToDll, NumberFormatInfo providerNumber)
+        private string ProcessDvd(string filePath, NumberFormatInfo providerNumber)
         {
             IsDvd = true;
             var path = Path.GetDirectoryName(filePath) ?? string.Empty;
@@ -186,7 +195,7 @@ namespace MediaInfo.DotNetWrapper
             return filePath;
         }
 
-        private void ExtractInfo(string filePath, string pathToDll, NumberFormatInfo providerNumber)
+        private void ExtractInfo(string filePath, NumberFormatInfo providerNumber)
         {
             using (var mediaInfo = new MediaInfo())
             {

--- a/src/MediaInfo.DotNetWrapper/Models/MediaStream.cs
+++ b/src/MediaInfo.DotNetWrapper/Models/MediaStream.cs
@@ -10,7 +10,10 @@ namespace MediaInfo.DotNetWrapper.Models
     /// </summary>
     /// <seealso cref="MarshalByRefObject" />
     [PublicAPI]
-    public abstract class MediaStream : MarshalByRefObject
+    public abstract class MediaStream 
+#if !NETSTANDARD1_3    
+    : MarshalByRefObject
+#endif
     {
         /// <summary>
         /// Gets or sets the media steam id.

--- a/src/MediaInfo.DotNetWrapper/NativeSystemMethods.cs
+++ b/src/MediaInfo.DotNetWrapper/NativeSystemMethods.cs
@@ -1,4 +1,5 @@
-﻿// ReSharper disable InconsistentNaming
+﻿#if !NETSTANDARD1_3
+// ReSharper disable InconsistentNaming
 using System;
 using System.Runtime.InteropServices;
 
@@ -34,3 +35,4 @@ namespace MediaInfo.DotNetWrapper
         internal static extern long GetDriveType(string driveLetter);
     }
 }
+#endif

--- a/src/MediaInfo.DotNetWrapper/Utils.cs
+++ b/src/MediaInfo.DotNetWrapper/Utils.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETSTANDARD1_3
+using System;
 
 namespace MediaInfo.DotNetWrapper
 {
@@ -17,3 +18,4 @@ namespace MediaInfo.DotNetWrapper
         }
     }
 }
+#endif


### PR DESCRIPTION
@StefH,

I was able to refactor the code and target .Net Standard 1.3. I conditionally excluded base class MarshalByRef when targeting net standard. Do you know why MediaStream is derived from MarshalByRef? Is it for convenience in case it's being marshaled by .Net remoting?

I also added Visual Studio Code build / debug settings.

Everything should be good to go except version number.
