### PR TITLE
fix: MediaInfoWrapper is not publicly exposed in net standard

### DIFF
--- a/src/MediaInfo.DotNetWrapper/MediaInfoWrapper.cs
+++ b/src/MediaInfo.DotNetWrapper/MediaInfoWrapper.cs
@@ -74,8 +74,11 @@ namespace MediaInfo.DotNetWrapper
         /// <param name="filePath">The file path.</param>
 #if !NETSTANDARD1_3        
         /// <param name="pathToDll">The path to DLL.</param>
+        protected
+#else
+        public
 #endif        
-        protected MediaInfoWrapper(string filePath
+        MediaInfoWrapper(string filePath
 #if !NETSTANDARD1_3
         , string pathToDll)
 #else


### PR DESCRIPTION
Hey Stef,

I accidentally made MediaInfoWrapper constructor is protected in net standard 1.3. Sorry for all the changes. Should probably add unit tests for MediaInfoWrapper.
